### PR TITLE
Allow Magic.cshtml to Use Magic LInks

### DIFF
--- a/examples/Passwordless.AspNetIdentity.Example/Pages/Account/Magic.cshtml.cs
+++ b/examples/Passwordless.AspNetIdentity.Example/Pages/Account/Magic.cshtml.cs
@@ -29,7 +29,7 @@ public class Magic : PageModel
             Success = false;
             return Page();
         }
-        
+
         var response = await _passwordlessClient.VerifyAuthenticationTokenAsync(token);
 
         if (!response.Success)
@@ -37,7 +37,7 @@ public class Magic : PageModel
             Success = false;
             return Page();
         }
-        
+
         var user = await _signInManager.UserManager.FindByIdAsync(response.UserId);
 
         if (user == null || !(await _signInManager.CanSignInAsync(user)))

--- a/examples/Passwordless.AspNetIdentity.Example/Pages/Account/Recovery.cshtml.cs
+++ b/examples/Passwordless.AspNetIdentity.Example/Pages/Account/Recovery.cshtml.cs
@@ -67,7 +67,6 @@ public class Recovery : PageModel
         var uriBuilder = new UriBuilder(url);
         var query = HttpUtility.ParseQueryString(uriBuilder.Query);
         query["token"] = token.Token;
-        query["email"] = user.Email;
         uriBuilder.Query = query.ToString();
 
         var message = $"""


### PR DESCRIPTION
Currently, `Magic.cshtml` only works with the DIY magic links built on the MGAT feature.  This will change the sample DIY magic link to work like the new magic link feature.

Testing done:
- i've validated the existing flow continues to work.
- the format matches the new magic link format.