### PR TITLE
Adding TTL to AuthenticationOptions

### DIFF
--- a/src/Passwordless/Helpers/Extensions/DoubleExtensions.cs
+++ b/src/Passwordless/Helpers/Extensions/DoubleExtensions.cs
@@ -1,8 +1,0 @@
-using System;
-
-namespace Passwordless.Helpers.Extensions;
-
-internal static class DoubleExtensions
-{
-    internal static int ToInt(this double value) => Convert.ToInt32(value);
-}

--- a/src/Passwordless/Helpers/Extensions/DoubleExtensions.cs
+++ b/src/Passwordless/Helpers/Extensions/DoubleExtensions.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Passwordless.Helpers.Extensions;
 
 internal static class DoubleExtensions
 {
-    internal static int ToInt(this double value) => (int)value;
+    internal static int ToInt(this double value) => Convert.ToInt32(value);
 }

--- a/src/Passwordless/Helpers/Extensions/DoubleExtensions.cs
+++ b/src/Passwordless/Helpers/Extensions/DoubleExtensions.cs
@@ -1,0 +1,6 @@
+namespace Passwordless.Helpers.Extensions;
+
+internal static class DoubleExtensions
+{
+    internal static int ToInt(this double value) => (int)value;
+}

--- a/src/Passwordless/Helpers/Extensions/FunctionalExtensions.cs
+++ b/src/Passwordless/Helpers/Extensions/FunctionalExtensions.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Passwordless.Helpers.Extensions;
+
+internal static class FunctionalExtensions
+{
+    internal static TOut Pipe<TIn, TOut>(this TIn input, Func<TIn, TOut> transform) => transform(input);
+}

--- a/src/Passwordless/Helpers/PasswordlessSerializerContext.cs
+++ b/src/Passwordless/Helpers/PasswordlessSerializerContext.cs
@@ -11,7 +11,7 @@ namespace Passwordless.Helpers;
 [JsonSerializable(typeof(RegisterTokenResponse))]
 [JsonSerializable(typeof(RegisterOptions))]
 [JsonSerializable(typeof(AuthenticationTokenResponse))]
-[JsonSerializable(typeof(AuthenticationOptions))]
+[JsonSerializable(typeof(AuthenticationOptionsRequest))]
 [JsonSerializable(typeof(VerifyTokenRequest))]
 [JsonSerializable(typeof(VerifiedUser))]
 [JsonSerializable(typeof(DeleteUserRequest))]

--- a/src/Passwordless/IPasswordlessClient.cs
+++ b/src/Passwordless/IPasswordlessClient.cs
@@ -23,7 +23,7 @@ public interface IPasswordlessClient
     /// This approach can be used to implement a "magic link"-style login and other similar scenarios.
     /// </summary>
     Task<AuthenticationTokenResponse> GenerateAuthenticationTokenAsync(
-        AuthenticationOptions options,
+        AuthenticationOptions authenticationOptions,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Passwordless/Models/AuthenticationOptions.cs
+++ b/src/Passwordless/Models/AuthenticationOptions.cs
@@ -1,8 +1,12 @@
+using System;
+
 namespace Passwordless.Models;
 
 /// <summary>
 /// Used to manually generate an authentication token.
 /// </summary>
 /// <param name="UserId">User identifier the token is intended for.</param>
-/// <param name="TimeToLive">Number of seconds the token will be valid for.</param>
-public record AuthenticationOptions(string UserId, int TimeToLive);
+/// <param name="TimeToLive">Optional. How long a token is valid for. Default value is 15 minutes.</param>
+public record AuthenticationOptions(string UserId, TimeSpan? TimeToLive = null);
+
+internal record AuthenticationOptionsRequest(string UserId, int? TimeToLIve = null);

--- a/src/Passwordless/Models/AuthenticationOptions.cs
+++ b/src/Passwordless/Models/AuthenticationOptions.cs
@@ -1,3 +1,8 @@
 namespace Passwordless.Models;
 
-public record AuthenticationOptions(string UserId);
+/// <summary>
+/// Used to manually generate an authentication token.
+/// </summary>
+/// <param name="UserId">User identifier the token is intended for.</param>
+/// <param name="TimeToLive">Number of seconds the token will be valid for.</param>
+public record AuthenticationOptions(string UserId, int TimeToLive);

--- a/src/Passwordless/Models/AuthenticationOptions.cs
+++ b/src/Passwordless/Models/AuthenticationOptions.cs
@@ -9,4 +9,4 @@ namespace Passwordless.Models;
 /// <param name="TimeToLive">Optional. How long a token is valid for. Default value is 15 minutes.</param>
 public record AuthenticationOptions(string UserId, TimeSpan? TimeToLive = null);
 
-internal record AuthenticationOptionsRequest(string UserId, int? TimeToLIve = null);
+internal record AuthenticationOptionsRequest(string UserId, int? TimeToLive = null);

--- a/src/Passwordless/PasswordlessClient.cs
+++ b/src/Passwordless/PasswordlessClient.cs
@@ -78,7 +78,7 @@ public class PasswordlessClient(HttpClient http, bool disposeClient, Passwordles
         CancellationToken cancellationToken = default)
     {
         using var response = await _http.PostAsJsonAsync("signin/generate-token",
-            new AuthenticationOptionsRequest(authenticationOptions.UserId, authenticationOptions.TimeToLive?.TotalSeconds.ToInt()),
+            new AuthenticationOptionsRequest(authenticationOptions.UserId, authenticationOptions.TimeToLive?.TotalSeconds.Pipe(Convert.ToInt32)),
             PasswordlessSerializerContext.Default.AuthenticationOptionsRequest,
             cancellationToken
         );

--- a/src/Passwordless/PasswordlessClient.cs
+++ b/src/Passwordless/PasswordlessClient.cs
@@ -73,11 +73,11 @@ public class PasswordlessClient(HttpClient http, bool disposeClient, Passwordles
 
     /// <inheritdoc />
     public async Task<AuthenticationTokenResponse> GenerateAuthenticationTokenAsync(
-        AuthenticationOptions options,
+        AuthenticationOptions authenticationOptions,
         CancellationToken cancellationToken = default)
     {
         using var response = await _http.PostAsJsonAsync("signin/generate-token",
-            options,
+            authenticationOptions,
             PasswordlessSerializerContext.Default.AuthenticationOptions,
             cancellationToken
         );

--- a/src/Passwordless/PasswordlessClient.cs
+++ b/src/Passwordless/PasswordlessClient.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Passwordless.Helpers;
+using Passwordless.Helpers.Extensions;
 using Passwordless.Models;
 
 namespace Passwordless;
@@ -77,8 +78,8 @@ public class PasswordlessClient(HttpClient http, bool disposeClient, Passwordles
         CancellationToken cancellationToken = default)
     {
         using var response = await _http.PostAsJsonAsync("signin/generate-token",
-            authenticationOptions,
-            PasswordlessSerializerContext.Default.AuthenticationOptions,
+            new AuthenticationOptionsRequest(authenticationOptions.UserId, authenticationOptions.TimeToLive?.TotalSeconds.ToInt()),
+            PasswordlessSerializerContext.Default.AuthenticationOptionsRequest,
             cancellationToken
         );
 


### PR DESCRIPTION
[PAS-370](https://bitwarden.atlassian.net/browse/PAS-370?atlOrigin=eyJpIjoiOGZlM2Q0ODVkMDMzNDg2MGE4YTE4MmI2NWIxODIzOGIiLCJwIjoiaiJ9)

This adds TTL to the GenerateAuthenticationTokenAsync AuthenticationOptions record.  It also adds an internal record that is used for the PasswordlessSerializerContext. This is because the API endpoint takes the TTL as an int of seconds. `TimeSpan` is a nicer way to define a segment of time, so I added the layer for ease of use.

Existing tests passed.

[PAS-370]: https://bitwarden.atlassian.net/browse/PAS-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ