### PR TITLE
.ASP.NET Identity SDK: Options pattern is not reading updated values

### DIFF
--- a/src/Passwordless.AspNetCore/IdentityBuilderExtensions.cs
+++ b/src/Passwordless.AspNetCore/IdentityBuilderExtensions.cs
@@ -22,37 +22,12 @@ public static class IdentityBuilderExtensions
     /// Adds the services to support <see cref="PasswordlessApiEndpointRouteBuilderExtensions.MapPasswordless(IEndpointRouteBuilder)" />
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection" />.</param>
-    /// <param name="configuration">The <see cref="IConfiguration" /> to use to bind to <see cref="PasswordlessAspNetCoreOptions" />. Generally it's own section.</param>
-    /// <returns>The <see cref="IServiceCollection" />.</returns>
-    public static IServiceCollection AddPasswordless<TUser>(this IServiceCollection services, IConfiguration configuration)
-        where TUser : class, new()
-    {
-        return services.AddPasswordlessCore(typeof(TUser), configuration.Bind, defaultScheme: null);
-    }
-
-    /// <summary>
-    /// Adds the services to support <see cref="PasswordlessApiEndpointRouteBuilderExtensions.MapPasswordless(IEndpointRouteBuilder)" />
-    /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection" />.</param>
     /// <param name="configure">Configures the <see cref="PasswordlessAspNetCoreOptions" />.</param>
     /// <returns>The <see cref="IServiceCollection" />.</returns>
     public static IServiceCollection AddPasswordless<TUser>(this IServiceCollection services, Action<PasswordlessAspNetCoreOptions> configure)
         where TUser : class, new()
     {
         return services.AddPasswordlessCore(typeof(TUser), configure, defaultScheme: null);
-    }
-
-
-    /// <summary>
-    /// Adds the services to support <see cref="PasswordlessApiEndpointRouteBuilderExtensions.MapPasswordless(IEndpointRouteBuilder)" />
-    /// </summary>
-    /// <param name="builder">The current <see cref="IdentityBuilder" /> instance.</param>
-    /// <param name="configuration">The <see cref="IConfiguration" /> to use to bind to <see cref="PasswordlessAspNetCoreOptions" />. Generally it's own section.</param>
-    /// <returns>The <see cref="IdentityBuilder" />.</returns>
-    public static IdentityBuilder AddPasswordless(this IdentityBuilder builder, IConfiguration configuration)
-    {
-        builder.Services.AddPasswordlessCore(builder.UserType, configuration.Bind, IdentityConstants.ApplicationScheme);
-        return builder;
     }
 
     /// <summary>
@@ -84,12 +59,6 @@ public static class IdentityBuilderExtensions
         // Add the SDK services but don't configure it there since ASP.NET Core options are a superset of their options.
         services.AddPasswordlessSdk(_ => { });
 
-        services.TryAddScoped(
-            typeof(IPasswordlessService<PasswordlessRegisterRequest>),
-            typeof(PasswordlessService<>).MakeGenericType(userType));
-
-        services.TryAddScoped<ICustomizeRegisterOptions, NoopCustomizeRegisterOptions>();
-
         // Override SDK options to come from ASP.NET Core options
         services.AddOptions<PasswordlessOptions>()
             .Configure<IOptions<PasswordlessAspNetCoreOptions>>((options, aspNetCoreOptionsAccessor) =>
@@ -99,6 +68,92 @@ public static class IdentityBuilderExtensions
                 options.ApiSecret = aspNetCoreOptions.ApiSecret;
                 options.ApiKey = aspNetCoreOptions.ApiKey;
             });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds the services to support <see cref="PasswordlessApiEndpointRouteBuilderExtensions.MapPasswordless(IEndpointRouteBuilder)" />
+    /// </summary>
+    /// <param name="builder">The current <see cref="IdentityBuilder" /> instance.</param>
+    /// <param name="configuration">The <see cref="IConfiguration" /> to use to bind to <see cref="PasswordlessAspNetCoreOptions" />. Generally it's own section.</param>
+    /// <returns>The <see cref="IdentityBuilder" />.</returns>
+    public static IServiceCollection AddPasswordless(this IdentityBuilder builder, IConfiguration configuration)
+    {
+        return builder.AddPasswordless(configuration, builder.UserType, IdentityConstants.ApplicationScheme);
+    }
+
+    /// <summary>
+    /// Adds the services to support <see cref="PasswordlessApiEndpointRouteBuilderExtensions.MapPasswordless(IEndpointRouteBuilder)" />
+    /// </summary>
+    /// <param name="builder">The current <see cref="IdentityBuilder" /> instance.</param>
+    /// <param name="configuration">The <see cref="IConfiguration" /> to use to bind to <see cref="PasswordlessAspNetCoreOptions" />. Generally it's own section.</param>
+    /// <returns>The <see cref="IdentityBuilder" />.</returns>
+    public static IServiceCollection AddPasswordless<TUserType>(this IdentityBuilder builder, IConfiguration configuration)
+    {
+        return builder.AddPasswordless(configuration, typeof(TUserType), null);
+    }
+
+    private static IServiceCollection AddPasswordless(this IdentityBuilder builder, IConfiguration configuration, Type? userType, string? defaultScheme)
+    {
+        var optionsBuilder = builder.Services
+            .AddOptions<PasswordlessAspNetCoreOptions>()
+            .Bind(configuration);
+
+        builder.Services.AddPasswordlessSdk(configuration);
+
+        return builder.Services.AddShared(userType ?? builder.UserType, optionsBuilder, IdentityConstants.ApplicationScheme);
+    }
+
+    /// <summary>
+    /// Adds the services to support <see cref="PasswordlessApiEndpointRouteBuilderExtensions.MapPasswordless(IEndpointRouteBuilder)" />
+    /// </summary>
+    /// <param name="builder">The current <see cref="IdentityBuilder" /> instance.</param>
+    /// <param name="path">The configuration path to use to bind to <see cref="PasswordlessAspNetCoreOptions" />.</param>
+    /// <returns>The <see cref="IServiceCollection" />.</returns>
+    public static IServiceCollection AddPasswordless(this IdentityBuilder builder, string path)
+    {
+        return builder.AddPasswordless(path, builder.UserType, IdentityConstants.ApplicationScheme);
+    }
+
+    /// <summary>
+    /// Adds the services to support <see cref="PasswordlessApiEndpointRouteBuilderExtensions.MapPasswordless(IEndpointRouteBuilder)" />
+    /// </summary>
+    /// <param name="builder">The current <see cref="IdentityBuilder" /> instance.</param>
+    /// <param name="path">The configuration path to use to bind to <see cref="PasswordlessAspNetCoreOptions" />.</param>
+    /// <returns>The <see cref="IServiceCollection" />.</returns>
+    public static IServiceCollection AddPasswordless<TUserType>(this IdentityBuilder builder, string path)
+    {
+        return builder.AddPasswordless(path, typeof(TUserType), null);
+    }
+
+    private static IServiceCollection AddPasswordless(this IdentityBuilder builder, string path, Type userType, string? defaultScheme)
+    {
+        var optionsBuilder = builder.Services
+            .AddOptions<PasswordlessAspNetCoreOptions>()
+            .BindConfiguration(path);
+
+        builder.Services.AddPasswordlessSdk(path);
+
+        return builder.Services.AddShared(userType ?? builder.UserType, optionsBuilder, IdentityConstants.ApplicationScheme);
+    }
+
+    private static IServiceCollection AddShared(this IServiceCollection services,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+        Type userType,
+        OptionsBuilder<PasswordlessAspNetCoreOptions> optionsBuilder,
+        string? defaultScheme)
+    {
+        if (!string.IsNullOrEmpty(defaultScheme))
+        {
+            optionsBuilder.Configure(o => o.SignInScheme = defaultScheme);
+        }
+
+        services.TryAddScoped(
+            typeof(IPasswordlessService<PasswordlessRegisterRequest>),
+            typeof(PasswordlessService<>).MakeGenericType(userType));
+
+        services.TryAddScoped<ICustomizeRegisterOptions, NoopCustomizeRegisterOptions>();
 
         return services;
     }

--- a/src/Passwordless/ServiceCollectionExtensions.cs
+++ b/src/Passwordless/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Dynamic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Passwordless;
@@ -66,7 +65,7 @@ public static class ServiceCollectionExtensions
     private static void RegisterDependencies(this IServiceCollection services)
     {
         services.AddHttpClient<IPasswordlessClient, PasswordlessClient>((http, sp) =>
-            new PasswordlessClient(http, sp.GetRequiredService<IOptions<PasswordlessOptions>>().Value)
+            new PasswordlessClient(http, sp.GetRequiredService<IOptionsSnapshot<PasswordlessOptions>>().Value)
         );
 
         // TODO: Get rid of this service, all consumers should use the interface


### PR DESCRIPTION
We currently cannot read updated values when the appsettings.json or environment variables change.

This pull request fixes this issue for the ASP.NET Identity SDK. This will allow us to change api keys and api secrets without having to restart any running instances.

Adds two new overloads as well accepting a `string path` as a parameter.

('tests fail due to an unrelated issue where libsodium is likely missing in our alpine-based image.')