### PR TITLE
Run `deploy` only on release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,6 +173,9 @@ jobs:
 
   # Dispatch a separate deployment workflow in a private repository
   deploy:
+    # Remove this if we end up adding more environments than just NuGet
+    if:  ${{ github.event_name == 'release' }}
+
     needs:
       - version
       - format


### PR DESCRIPTION
Looks like when the matrix has all cases excluded, the job still runs but with no parameters set. Didn't think that it would be the case -- this PR fixes that.