### PR TITLE
Update test container healthchecks

### DIFF
--- a/tests/Passwordless.Tests.Infra/TestApi.cs
+++ b/tests/Passwordless.Tests.Infra/TestApi.cs
@@ -40,6 +40,8 @@ public class TestApi : IAsyncDisposable
             .WithEnvironment("ASPNETCORE_HTTP_PORTS", ApiPort.ToString(CultureInfo.InvariantCulture))
             // We need the management key to create apps
             .WithEnvironment("PasswordlessManagement__ManagementKey", ManagementKey)
+            // Set the mail sink file path to a known value
+            .WithEnvironment("Mail__File__Path", "mail.md")
             .WithPortBinding(ApiPort, true)
             // Wait until the API is launched, has performed migrations, and is ready to accept requests
             .WithWaitStrategy(Wait

--- a/tests/Passwordless.Tests.Infra/TestApi.cs
+++ b/tests/Passwordless.Tests.Infra/TestApi.cs
@@ -45,7 +45,12 @@ public class TestApi : IAsyncDisposable
             .WithWaitStrategy(Wait
                 .ForUnixContainer()
                 .UntilHttpRequestIsSucceeded(r => r
-                    .ForPath("/")
+                    .ForPath("/health/http")
+                    .ForPort(ApiPort)
+                    .ForStatusCode(HttpStatusCode.OK)
+                )
+                .UntilHttpRequestIsSucceeded(r => r
+                    .ForPath("/health/storage")
                     .ForPort(ApiPort)
                     .ForStatusCode(HttpStatusCode.OK)
                 )


### PR DESCRIPTION
Tests are failing due to a recent change: root page (`/`) no longer has a handler and migrations are performed automatically.

This updates the health checks to fix it.

There is also another issue, with the file path for the mail sink. In development mode it's `../mail.md` which resolves to `/opt/mail.md`. The app doesn't have access to that file.

This also fixes that.