### PR TITLE
PAS-542 | Delay and consolidate coercion and validation of `PasswordlessOptions`

### DIFF
--- a/examples/Passwordless.AspNetIdentity.Example/Program.cs
+++ b/examples/Passwordless.AspNetIdentity.Example/Program.cs
@@ -94,7 +94,7 @@ static async Task<IResult> StepUp(IOptions<PasswordlessOptions> options, HttpCon
 {
     var http = new HttpClient
     {
-        BaseAddress = new Uri(options.Value.ApiUrl),
+        BaseAddress = new Uri(options.Value.ApiUrl ?? PasswordlessOptions.CloudApiUrl),
         DefaultRequestHeaders = { { "ApiSecret", options.Value.ApiSecret } }
     };
 

--- a/src/Passwordless/IPasswordlessClient.cs
+++ b/src/Passwordless/IPasswordlessClient.cs
@@ -14,7 +14,7 @@ public interface IPasswordlessClient
     /// Creates a register token which will be used by your frontend to negotiate the creation of a WebAuth credential.
     /// </summary>
     Task<RegisterTokenResponse> CreateRegisterTokenAsync(
-        RegisterOptions options,
+        RegisterOptions registerOptions,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Passwordless/PasswordlessOptions.cs
+++ b/src/Passwordless/PasswordlessOptions.cs
@@ -6,7 +6,7 @@ namespace Passwordless;
 public class PasswordlessOptions
 {
     /// <summary>
-    /// Passwordless Cloud Url
+    /// Passwordless Cloud Url.
     /// </summary>
     public const string CloudApiUrl = "https://v4.passwordless.dev";
 
@@ -14,9 +14,9 @@ public class PasswordlessOptions
     /// Gets or sets the url to use for Passwordless operations.
     /// </summary>
     /// <remarks>
-    /// Defaults to <see cref="CloudApiUrl" />.
+    /// If not set, defaults to <see cref="CloudApiUrl" />.
     /// </remarks>
-    public string ApiUrl { get; set; } = CloudApiUrl;
+    public string? ApiUrl { get; set; }
 
     /// <summary>
     /// Gets or sets the secret API key used to authenticate with the Passwordless API.

--- a/src/Passwordless/ServiceCollectionExtensions.cs
+++ b/src/Passwordless/ServiceCollectionExtensions.cs
@@ -19,11 +19,7 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         Action<PasswordlessOptions> configureOptions)
     {
-        services.AddOptions<PasswordlessOptions>()
-            .Configure(configureOptions)
-            .PostConfigure(options => options.ApiUrl ??= PasswordlessOptions.CloudApiUrl)
-            .Validate(options => !string.IsNullOrEmpty(options.ApiSecret), "Passwordless: Missing ApiSecret");
-
+        services.AddOptions<PasswordlessOptions>().Configure(configureOptions);
         services.RegisterDependencies();
 
         return services;
@@ -42,10 +38,7 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        services.AddOptions<PasswordlessOptions>()
-            .Configure(configuration.Bind)
-            .Validate(options => !string.IsNullOrEmpty(options.ApiSecret), "Passwordless: Missing ApiSecret");
-
+        services.AddOptions<PasswordlessOptions>().Configure(configuration.Bind);
         services.RegisterDependencies();
 
         return services;
@@ -68,7 +61,6 @@ public static class ServiceCollectionExtensions
         string section)
     {
         services.AddOptions<PasswordlessOptions>().BindConfiguration(section);
-
         services.RegisterDependencies();
 
         return services;

--- a/tests/Passwordless.Tests.Infra/PasswordlessApplication.cs
+++ b/tests/Passwordless.Tests.Infra/PasswordlessApplication.cs
@@ -1,15 +1,11 @@
-using Microsoft.Extensions.DependencyInjection;
-
 namespace Passwordless.Tests.Infra;
 
 public record PasswordlessApplication(string Name, string ApiUrl, string ApiSecret, string ApiKey)
 {
-    public IPasswordlessClient CreateClient() =>
-        // Initialize using a service container to cover more code paths in tests
-        new ServiceCollection().AddPasswordlessSdk(o =>
-        {
-            o.ApiUrl = ApiUrl;
-            o.ApiKey = ApiKey;
-            o.ApiSecret = ApiSecret;
-        }).BuildServiceProvider().GetRequiredService<IPasswordlessClient>();
+    public IPasswordlessClient CreateClient() => new PasswordlessClient(new PasswordlessOptions
+    {
+        ApiUrl = ApiUrl,
+        ApiSecret = ApiSecret,
+        ApiKey = ApiKey
+    });
 }

--- a/tests/Passwordless.Tests/MagicLinksTests.cs
+++ b/tests/Passwordless.Tests/MagicLinksTests.cs
@@ -16,7 +16,12 @@ public class MagicLinksTests(TestApiFixture api, ITestOutputHelper testOutput) :
     {
         // Arrange
         var passwordless = await Api.CreateClientAsync();
-        var request = new SendMagicLinkRequest("test@passwordless.dev", "https://www.example.com?token=$TOKEN", "user", new TimeSpan(0, 15, 0));
+
+        var request = new SendMagicLinkRequest(
+            "test@passwordless.dev",
+            "https://www.example.com?token=$TOKEN", "user",
+            new TimeSpan(0, 15, 0)
+        );
 
         // Act
         var action = async () => await passwordless.SendMagicLinkAsync(request, CancellationToken.None);
@@ -30,7 +35,12 @@ public class MagicLinksTests(TestApiFixture api, ITestOutputHelper testOutput) :
     {
         // Arrange
         var passwordless = await Api.CreateClientAsync();
-        var request = new SendMagicLinkRequest("test@passwordless.dev", "https://www.example.com?token=$TOKEN", "user", null);
+
+        var request = new SendMagicLinkRequest(
+            "test@passwordless.dev",
+            "https://www.example.com?token=$TOKEN", "user",
+            null
+        );
 
         // Act
         var action = async () => await passwordless.SendMagicLinkAsync(request, CancellationToken.None);

--- a/tests/Passwordless.Tests/ServiceRegistrationTests.cs
+++ b/tests/Passwordless.Tests/ServiceRegistrationTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Passwordless.Tests;
+
+public class ServiceRegistrationTests
+{
+    [Fact]
+    public async Task I_can_register_a_client_with_invalid_credentials_and_not_receive_an_error_until_it_is_used()
+    {
+        // Arrange
+        var services = new ServiceCollection()
+            .AddPasswordlessSdk(o =>
+            {
+                o.ApiSecret = "";
+                o.ApiKey = "";
+            })
+            .BuildServiceProvider();
+
+        var passwordless = services.GetRequiredService<IPasswordlessClient>();
+
+        // Act & assert
+        await Assert.ThrowsAnyAsync<InvalidOperationException>(async () =>
+            await passwordless.CreateRegisterTokenAsync(new RegisterOptions("user123", "User"))
+        );
+    }
+}


### PR DESCRIPTION
This PR does the following:

1. Moves the validation of `ApiSecret` from service registration (eager) to when the API requests are actually sent (lazy).
  - This makes it possible to register a Passwordless client with invalid `ApiSecret` and have it fail only when the client is actually used.
  - It prevents an issue in a DI scenario where a service may depend on Passwordless client, but not rely on it when the secret is not provided (think the initialization flow in the Admin Console). Previously, the validation would prevent the service from being created entirely. Now it will only fail when any of the methods on the client are called.
2. Moves the coercion of the `ApiUrl` (defaulting to `CloudApiUrl` when not set) from service registration to client initialization.
  - This makes it so that `PasswordlessClient` can be initialized with a `null` value of `ApiUrl`, even without DI, resulting in a more uniform behavior.
  - This makes the nullability annotations more reasonable, as previously we used `ApiUrl ??= CloudApiUrl` even though the former can never be `null` in our type model.

Both of these changes also significantly simplify the service registration code, while making all initialization routes (DI or non-DI) work the same way.