### PR TITLE
Add `Passwordless.AspNetCore` registration overloads that support `IConfiguration` properly

### DIFF
--- a/src/Passwordless.AspNetCore/IdentityBuilderExtensions.cs
+++ b/src/Passwordless.AspNetCore/IdentityBuilderExtensions.cs
@@ -173,7 +173,7 @@ public static class IdentityBuilderExtensions
         identity.Services.AddPasswordlessSdk(configuration);
 
         identity.Services.AddPasswordlessIdentity(
-            identity.UserType,
+            typeof(TUserType),
             o => o.Bind(configuration),
             IdentityConstants.ApplicationScheme
         );

--- a/src/Passwordless/ServiceCollectionExtensions.cs
+++ b/src/Passwordless/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Passwordless;
@@ -12,67 +11,62 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// </summary>
 public static class ServiceCollectionExtensions
 {
-    /// <summary>
-    /// Adds and configures Passwordless-related services.
-    /// </summary>
-    public static IServiceCollection AddPasswordlessSdk(
+    private static IServiceCollection AddPasswordlessSdk(
         this IServiceCollection services,
-        Action<PasswordlessOptions> configureOptions)
+        Action<OptionsBuilder<PasswordlessOptions>> configureOptions)
     {
-        services.AddOptions<PasswordlessOptions>().Configure(configureOptions);
-        services.RegisterDependencies();
+        // Options
+        configureOptions(
+            services.AddOptions<PasswordlessOptions>()
+        );
 
-        return services;
-    }
-
-    /// <summary>
-    /// Adds and configures Passwordless-related services.
-    /// </summary>
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("This method is incompatible with assembly trimming.")]
-#endif
-#if NET7_0_OR_GREATER
-    [RequiresDynamicCode("This method is incompatible with native AOT compilation.")]
-#endif
-    public static IServiceCollection AddPasswordlessSdk(
-        this IServiceCollection services,
-        IConfiguration configuration)
-    {
-        services.AddOptions<PasswordlessOptions>().Configure(configuration.Bind);
-        services.RegisterDependencies();
-
-        return services;
-    }
-
-    /// <summary>
-    /// Adds and configures Passwordless-related services.
-    /// </summary>
-    /// <param name="services"></param>
-    /// <param name="section"></param>
-    /// <returns></returns>
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("This method is incompatible with assembly trimming.")]
-#endif
-#if NET7_0_OR_GREATER
-    [RequiresDynamicCode("This method is incompatible with native AOT compilation.")]
-#endif
-    public static IServiceCollection AddPasswordlessSdk(
-        this IServiceCollection services,
-        string section)
-    {
-        services.AddOptions<PasswordlessOptions>().BindConfiguration(section);
-        services.RegisterDependencies();
-
-        return services;
-    }
-
-    private static void RegisterDependencies(this IServiceCollection services)
-    {
+        // Client
         services.AddHttpClient<IPasswordlessClient, PasswordlessClient>((http, sp) =>
             new PasswordlessClient(http, sp.GetRequiredService<IOptionsSnapshot<PasswordlessOptions>>().Value)
         );
 
         // TODO: Get rid of this service, all consumers should use the interface
         services.AddTransient(sp => (PasswordlessClient)sp.GetRequiredService<IPasswordlessClient>());
+
+        return services;
     }
+
+    /// <summary>
+    /// Adds and configures Passwordless-related services.
+    /// </summary>
+    public static IServiceCollection AddPasswordlessSdk(
+        this IServiceCollection services,
+        Action<PasswordlessOptions> configureOptions) =>
+        services.AddPasswordlessSdk(o => o.Configure(configureOptions));
+
+    /// <summary>
+    /// Adds and configures Passwordless-related services.
+    /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("This method is incompatible with assembly trimming.")]
+#endif
+#if NET7_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("This method is incompatible with native AOT compilation.")]
+#endif
+    public static IServiceCollection AddPasswordlessSdk(
+        this IServiceCollection services,
+        IConfiguration configuration) =>
+        services.AddPasswordlessSdk(o => o.Bind(configuration));
+
+    /// <summary>
+    /// Adds and configures Passwordless-related services.
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="configurationSection"></param>
+    /// <returns></returns>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("This method is incompatible with assembly trimming.")]
+#endif
+#if NET7_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("This method is incompatible with native AOT compilation.")]
+#endif
+    public static IServiceCollection AddPasswordlessSdk(
+        this IServiceCollection services,
+        string configurationSection) =>
+        services.AddPasswordlessSdk(o => o.BindConfiguration(configurationSection));
 }

--- a/tests/Passwordless.Tests/Passwordless.Tests.csproj
+++ b/tests/Passwordless.Tests/Passwordless.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />

--- a/tests/Passwordless.Tests/ServiceRegistrationTests.cs
+++ b/tests/Passwordless.Tests/ServiceRegistrationTests.cs
@@ -1,12 +1,69 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Passwordless.Tests;
 
 public class ServiceRegistrationTests
 {
+    [Fact]
+    public void I_can_register_a_client_with_options_derived_from_configuration()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection([
+                new KeyValuePair<string, string?>("Passwordless:ApiSecret", "foo"),
+                new KeyValuePair<string, string?>("Passwordless:ApiKey", "bar")
+            ])
+            .Build();
+
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration)
+            .AddPasswordlessSdk(configuration.GetSection("Passwordless"))
+            .BuildServiceProvider();
+
+        // Act
+        var options = services.GetRequiredService<IOptions<PasswordlessOptions>>();
+
+        // Assert
+        options.Value.ApiSecret.Should().Be("foo");
+        options.Value.ApiKey.Should().Be("bar");
+    }
+
+    [Fact]
+    public void I_can_register_a_client_and_update_its_options_at_any_point_in_time()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection([
+                new KeyValuePair<string, string?>("Passwordless:ApiSecret", "foo"),
+                new KeyValuePair<string, string?>("Passwordless:ApiKey", "bar")
+            ])
+            .Build();
+
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration)
+            .AddPasswordlessSdk(configuration.GetSection("Passwordless"))
+            .BuildServiceProvider();
+
+        // Act
+        foreach (var provider in configuration.Providers)
+        {
+            provider.Set("Passwordless:ApiSecret", "baz");
+            provider.Set("Passwordless:ApiKey", "zap");
+        }
+
+        // Assert
+        var options = services.GetRequiredService<IOptions<PasswordlessOptions>>();
+        options.Value.ApiSecret.Should().Be("baz");
+        options.Value.ApiKey.Should().Be("zap");
+    }
+
     [Fact]
     public async Task I_can_register_a_client_with_invalid_credentials_and_not_receive_an_error_until_it_is_used()
     {
@@ -25,5 +82,28 @@ public class ServiceRegistrationTests
         await Assert.ThrowsAnyAsync<InvalidOperationException>(async () =>
             await passwordless.CreateRegisterTokenAsync(new RegisterOptions("user123", "User"))
         );
+    }
+
+    [Fact]
+    public void I_can_register_a_client_and_retrieve_a_new_copy_for_each_scope()
+    {
+        // Arrange
+        var services = new ServiceCollection()
+            .AddPasswordlessSdk(o =>
+            {
+                o.ApiSecret = "foo";
+                o.ApiKey = "bar";
+            })
+            .BuildServiceProvider();
+
+        // Act
+        using var scope1 = services.CreateScope();
+        var client1 = scope1.ServiceProvider.GetRequiredService<IPasswordlessClient>();
+
+        using var scope2 = services.CreateScope();
+        var client2 = scope2.ServiceProvider.GetRequiredService<IPasswordlessClient>();
+
+        // Assert
+        client1.Should().NotBeSameAs(client2);
     }
 }


### PR DESCRIPTION
This PR fixes an issue where, when registering the Passwordless Identity integration, the core options (`PasswordlessOptions`) were not initialized with reload-tracking, due to the fact that the SDK was registered with `services.AddPasswordlessSdk(_ => {})`. Even though we forwarded the options by re-registering them inside the Identity integration, this did not forward the corresponding reload token.

I also added a few tests for configuration-related scenarios, although properly e2e testing configuration routing is quite challenging.