### PR TITLE
PAS-563 | RPID is not mapped correctly when retrieving credentials

### DIFF
--- a/src/Passwordless/Models/Credential.cs
+++ b/src/Passwordless/Models/Credential.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Passwordless;
 
@@ -32,7 +33,7 @@ public record Credential(
     DateTime CreatedAt,
     Guid AaGuid,
     DateTime LastUsedAt,
-    string RpId,
+    [property: JsonPropertyName("rpid")] string RpId,
     string Origin,
     string Country,
     string Device,


### PR DESCRIPTION
We would need a new release after merging this.