### PR TITLE
PAS-572 | Remove default path for mail file provider

### DIFF
--- a/tests/Passwordless.Tests.Infra/TestApi.cs
+++ b/tests/Passwordless.Tests.Infra/TestApi.cs
@@ -40,8 +40,6 @@ public class TestApi : IAsyncDisposable
             .WithEnvironment("ASPNETCORE_HTTP_PORTS", ApiPort.ToString(CultureInfo.InvariantCulture))
             // We need the management key to create apps
             .WithEnvironment("PasswordlessManagement__ManagementKey", ManagementKey)
-            // Set the mail sink file path to a known value
-            .WithEnvironment("Mail__File__Path", "mail.md")
             .WithPortBinding(ApiPort, true)
             // Wait until the API is launched, has performed migrations, and is ready to accept requests
             .WithWaitStrategy(Wait


### PR DESCRIPTION
We need compatibility for the mail providers defined in: https://github.com/bitwarden/passwordless-server/commit/8697acd192ea5a42687fb542aaff9908050ceee3

Since https://github.com/bitwarden/passwordless-server/commit/2d9dd79d36d2ff27f460875ce9cee2a9719de32c, we are setting the path directly in the image itself.

This configuration we're removing in this pull request is redundant, and will regardless no longer work as it's no longer compatible with the new format.