### PR TITLE
Updated Codecov action and removed token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,8 +128,6 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   # Pack the output into NuGet packages
   pack:


### PR DESCRIPTION
### Ticket

https://bitwarden.atlassian.net/browse/VULN-127

### Description

Codecov updated the codecov/codecov-action GitHub action. In this new version, it no longer requires a CODECOV_TOKEN in the workflows. This PR will update the action to t
he current latest version (5.1.2) and remove the CODECOV_TOKEN for the action.

Note: The codecov/test-results-action GitHub action still requires a token, and can not be removed yet.

